### PR TITLE
FIX: add check for 64-bit macOS in Try_Browser.

### DIFF
--- a/src/os/posix/host-lib.c
+++ b/src/os/posix/host-lib.c
@@ -1100,7 +1100,7 @@ static int Try_Browser(char *browser, REBCHR *url)
 ***********************************************************************/
 {
 	if (
-#if defined(TO_OSX) || defined(TO_OSXI)
+#if defined(TO_OSX) || defined(TO_OSXI) || defined(TO_OSX_X64)
 		Try_Browser("/usr/bin/open", url)
 #else
 		Try_Browser("xdg-open", url)


### PR DESCRIPTION
Since 64-bit builds define `TO_OSX_X64` rather than `TO_OSXI`, `browse` currently attempts to exec `xdg-open` and `x-www-browser` rather than leveraging `open`.

N.B. The ifdef here is pretty ugly; it's probably worth factoring out the platform check as some forks have already done.