### PR TITLE
ATRONIX/FEAT: Add a native 'access-os'

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -188,6 +188,9 @@ Access: [
 
 	call-fail:          [{external process failed:} :arg1]
 
+	permission-denied: 	[{permission denied}]
+	process-not-found: 	[{process not found:} :arg1]
+
 ]
 
 Command: [

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -1062,152 +1062,57 @@ REBNATIVE(access_os)
 	REBVAL *field = D_ARG(1);
 	REBOOL set = D_REF(2);
 	REBVAL *val = D_ARG(3);
+	REBINT ret = 0;
+	REBVAL *pid = 0;
 
 	switch (VAL_WORD_CANON(field)) {
 		case SYM_UID:
 			if (set) {
 				if (IS_INTEGER(val)) {
-					REBINT ret = OS_SET_UID(VAL_INT32(val));
-					if (ret < 0) {
-						switch (ret) {
-							case OS_ENA:
-								return R_NONE;
-							case OS_EPERM:
-								Trap0(RE_PERMISSION_DENIED);
-								break;
-							case OS_EINVAL:
-								Trap_Arg(val);
-								break;
-							default:
-								Trap_Arg(val);
-								break;
-						}
-					} else {
-						SET_INTEGER(D_RET, ret);
-						return R_RET;
-					}
+					ret = OS_SET_UID(VAL_INT32(val));
 				} else {
 					Trap_Arg(val);
 				}
 			} else {
-				REBINT ret = OS_GET_UID();
-				if (ret < 0) {
-					return R_NONE;
-				} else {
-					SET_INTEGER(D_RET, ret);
-					return R_RET;
-				}
+				ret = OS_GET_UID();
 			}
 			break;
 		case SYM_GID:
 			if (set) {
 				if (IS_INTEGER(val)) {
-					REBINT ret = OS_SET_GID(VAL_INT32(val));
-					if (ret < 0) {
-						switch (ret) {
-							case OS_ENA:
-								return R_NONE;
-							case OS_EPERM:
-								Trap0(RE_PERMISSION_DENIED);
-								break;
-							case OS_EINVAL:
-								Trap_Arg(val);
-								break;
-							default:
-								Trap_Arg(val);
-								break;
-						}
-					} else {
-						SET_INTEGER(D_RET, ret);
-						return R_RET;
-					}
+					ret = OS_SET_GID(VAL_INT32(val));
 				} else {
 					Trap_Arg(val);
 				}
 			} else {
-				REBINT ret = OS_GET_GID();
-				if (ret < 0) {
-					return R_NONE;
-				} else {
-					SET_INTEGER(D_RET, ret);
-					return R_RET;
-				}
+				ret = OS_GET_GID();
 			}
 			break;
 		case SYM_EUID:
 			if (set) {
 				if (IS_INTEGER(val)) {
-					REBINT ret = OS_SET_EUID(VAL_INT32(val));
-					if (ret < 0) {
-						switch (ret) {
-							case OS_ENA:
-								return R_NONE;
-							case OS_EPERM:
-								Trap0(RE_PERMISSION_DENIED);
-								break;
-							case OS_EINVAL:
-								Trap_Arg(val);
-								break;
-							default:
-								Trap_Arg(val);
-								break;
-						}
-					} else {
-						SET_INTEGER(D_RET, ret);
-						return R_RET;
-					}
+					ret = OS_SET_EUID(VAL_INT32(val));
 				} else {
 					Trap_Arg(val);
 				}
 			} else {
-				REBINT ret = OS_GET_EUID();
-				if (ret < 0) {
-					return R_NONE;
-				} else {
-					SET_INTEGER(D_RET, ret);
-					return R_RET;
-				}
+				ret = OS_GET_EUID();
 			}
 			break;
 		case SYM_EGID:
 			if (set) {
 				if (IS_INTEGER(val)) {
-					REBINT ret = OS_SET_EGID(VAL_INT32(val));
-					if (ret < 0) {
-						switch (ret) {
-							case OS_ENA:
-								return R_NONE;
-							case OS_EPERM:
-								Trap0(RE_PERMISSION_DENIED);
-								break;
-							case OS_EINVAL:
-								Trap_Arg(val);
-								break;
-							default:
-								Trap_Arg(val);
-								break;
-						}
-					} else {
-						SET_INTEGER(D_RET, ret);
-						return R_RET;
-					}
+					ret = OS_SET_EGID(VAL_INT32(val));
 				} else {
 					Trap_Arg(val);
 				}
 			} else {
-				REBINT ret = OS_GET_EGID();
-				if (ret < 0) {
-					return R_NONE;
-				} else {
-					SET_INTEGER(D_RET, ret);
-					return R_RET;
-				}
+				ret = OS_GET_EGID();
 			}
 			break;
 		case SYM_PID:
 			if (set) {
-				REBINT ret = 0;
-				REBVAL *pid = val;
+				pid = val;
 				REBVAL *arg = val;
 				if (IS_INTEGER(val)) {
 					ret = OS_KILL(VAL_INT32(pid));
@@ -1230,39 +1135,39 @@ REBNATIVE(access_os)
 				} else {
 					Trap_Arg(val);
 				}
-
-				if (ret < 0) {
-					switch (ret) {
-						case OS_ENA:
-							return R_NONE;
-						case OS_EPERM:
-							Trap0(RE_PERMISSION_DENIED);
-							break;
-						case OS_EINVAL:
-							Trap_Arg(arg);
-							break;
-						case OS_ESRCH:
-							Trap1(RE_PROCESS_NOT_FOUND, pid);
-							break;
-						default:
-							Trap_Arg(val);
-							break;
-					}
-				} else {
-					SET_INTEGER(D_RET, ret);
-					return R_RET;
-				}
 			} else {
-				REBINT ret = OS_GET_PID();
-				if (ret < 0) {
-					return R_NONE;
-				} else {
-					SET_INTEGER(D_RET, ret);
-					return R_RET;
-				}
+				ret = OS_GET_PID();
 			}
 			break;
 		default:
 			Trap_Arg(field);
+	}
+
+	if(ret > 0) {
+		SET_INTEGER(D_RET, ret);
+		return R_RET;
+	}
+
+	if (ret == 0) {
+		SET_TRUE(D_RET);
+		return R_RET;
+	}
+
+	switch (ret) {
+		case OS_ENA:
+			Trap1(RE_NOT_HERE, field);
+			break;
+		case OS_EPERM:
+			Trap0(RE_PERMISSION_DENIED);
+			break;
+		case OS_EINVAL:
+			Trap_Arg(val);
+			break;
+		case OS_ESRCH:
+			Trap1(RE_PROCESS_NOT_FOUND, pid);
+			break;
+		default:
+			Trap_Arg(val);
+			break;
 	}
 }

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -1047,3 +1047,222 @@ chk_neg:
 
 	return R_RET;
 }
+
+/**********************************************************************/
+//
+//	access-os: native[
+//		{Access to various operating system functions (getuid, setuid, getpid, kill, etc.)}
+//		field [word!] "Valid words: uid, euid, gid, egid, pid"
+//		/set          "To set or kill pid (sig 15)"
+//		value [integer! block!] "Argument, such as uid, gid, or pid (in which case, it could be a block with the signal no)"
+//	]
+//
+REBNATIVE(access_os)
+{
+	REBVAL *field = D_ARG(1);
+	REBOOL set = D_REF(2);
+	REBVAL *val = D_ARG(3);
+
+	switch (VAL_WORD_CANON(field)) {
+		case SYM_UID:
+			if (set) {
+				if (IS_INTEGER(val)) {
+					REBINT ret = OS_SET_UID(VAL_INT32(val));
+					if (ret < 0) {
+						switch (ret) {
+							case OS_ENA:
+								return R_NONE;
+							case OS_EPERM:
+								Trap0(RE_PERMISSION_DENIED);
+								break;
+							case OS_EINVAL:
+								Trap_Arg(val);
+								break;
+							default:
+								Trap_Arg(val);
+								break;
+						}
+					} else {
+						SET_INTEGER(D_RET, ret);
+						return R_RET;
+					}
+				} else {
+					Trap_Arg(val);
+				}
+			} else {
+				REBINT ret = OS_GET_UID();
+				if (ret < 0) {
+					return R_NONE;
+				} else {
+					SET_INTEGER(D_RET, ret);
+					return R_RET;
+				}
+			}
+			break;
+		case SYM_GID:
+			if (set) {
+				if (IS_INTEGER(val)) {
+					REBINT ret = OS_SET_GID(VAL_INT32(val));
+					if (ret < 0) {
+						switch (ret) {
+							case OS_ENA:
+								return R_NONE;
+							case OS_EPERM:
+								Trap0(RE_PERMISSION_DENIED);
+								break;
+							case OS_EINVAL:
+								Trap_Arg(val);
+								break;
+							default:
+								Trap_Arg(val);
+								break;
+						}
+					} else {
+						SET_INTEGER(D_RET, ret);
+						return R_RET;
+					}
+				} else {
+					Trap_Arg(val);
+				}
+			} else {
+				REBINT ret = OS_GET_GID();
+				if (ret < 0) {
+					return R_NONE;
+				} else {
+					SET_INTEGER(D_RET, ret);
+					return R_RET;
+				}
+			}
+			break;
+		case SYM_EUID:
+			if (set) {
+				if (IS_INTEGER(val)) {
+					REBINT ret = OS_SET_EUID(VAL_INT32(val));
+					if (ret < 0) {
+						switch (ret) {
+							case OS_ENA:
+								return R_NONE;
+							case OS_EPERM:
+								Trap0(RE_PERMISSION_DENIED);
+								break;
+							case OS_EINVAL:
+								Trap_Arg(val);
+								break;
+							default:
+								Trap_Arg(val);
+								break;
+						}
+					} else {
+						SET_INTEGER(D_RET, ret);
+						return R_RET;
+					}
+				} else {
+					Trap_Arg(val);
+				}
+			} else {
+				REBINT ret = OS_GET_EUID();
+				if (ret < 0) {
+					return R_NONE;
+				} else {
+					SET_INTEGER(D_RET, ret);
+					return R_RET;
+				}
+			}
+			break;
+		case SYM_EGID:
+			if (set) {
+				if (IS_INTEGER(val)) {
+					REBINT ret = OS_SET_EGID(VAL_INT32(val));
+					if (ret < 0) {
+						switch (ret) {
+							case OS_ENA:
+								return R_NONE;
+							case OS_EPERM:
+								Trap0(RE_PERMISSION_DENIED);
+								break;
+							case OS_EINVAL:
+								Trap_Arg(val);
+								break;
+							default:
+								Trap_Arg(val);
+								break;
+						}
+					} else {
+						SET_INTEGER(D_RET, ret);
+						return R_RET;
+					}
+				} else {
+					Trap_Arg(val);
+				}
+			} else {
+				REBINT ret = OS_GET_EGID();
+				if (ret < 0) {
+					return R_NONE;
+				} else {
+					SET_INTEGER(D_RET, ret);
+					return R_RET;
+				}
+			}
+			break;
+		case SYM_PID:
+			if (set) {
+				REBINT ret = 0;
+				REBVAL *pid = val;
+				REBVAL *arg = val;
+				if (IS_INTEGER(val)) {
+					ret = OS_KILL(VAL_INT32(pid));
+				} else if (IS_BLOCK(val)) {
+					REBVAL *sig = NULL;
+
+					if (VAL_LEN(val) != 2) {
+						Trap_Arg(val);
+					}
+					pid = VAL_BLK_SKIP(val, 0);
+					sig = VAL_BLK_SKIP(val, 1);
+					if (!IS_INTEGER(pid)) {
+						Trap_Arg(pid);
+					}
+					if (!IS_INTEGER(sig)) {
+						Trap_Arg(sig);
+					}
+					ret = OS_SEND_SIGNAL(VAL_INT32(pid), VAL_INT32(sig));
+					arg = sig;
+				} else {
+					Trap_Arg(val);
+				}
+
+				if (ret < 0) {
+					switch (ret) {
+						case OS_ENA:
+							return R_NONE;
+						case OS_EPERM:
+							Trap0(RE_PERMISSION_DENIED);
+							break;
+						case OS_EINVAL:
+							Trap_Arg(arg);
+							break;
+						case OS_ESRCH:
+							Trap1(RE_PROCESS_NOT_FOUND, pid);
+							break;
+						default:
+							Trap_Arg(val);
+							break;
+					}
+				} else {
+					SET_INTEGER(D_RET, ret);
+					return R_RET;
+				}
+			} else {
+				REBINT ret = OS_GET_PID();
+				if (ret < 0) {
+					return R_NONE;
+				} else {
+					SET_INTEGER(D_RET, ret);
+					return R_RET;
+				}
+			}
+			break;
+		default:
+			Trap_Arg(field);
+	}
+}

--- a/src/include/reb-defs.h
+++ b/src/include/reb-defs.h
@@ -36,6 +36,12 @@ typedef void *REBSER;
 typedef void *REBOBJ;
 #endif
 
+/* These used for access-os native function */
+#define OS_ENA    -1
+#define OS_EINVAL -2
+#define OS_EPERM  -3
+#define OS_ESRCH  -4
+
 #pragma pack(4)
 
 // X/Y coordinate pair as floats:

--- a/src/os/posix/host-lib.c
+++ b/src/os/posix/host-lib.c
@@ -139,6 +139,185 @@ int pipe2(int pipefd[2], int flags); //to avoid "implicit-function-declaration" 
 **
 ***********************************************************************/
 
+
+/***********************************************************************
+**
+*/	REBINT OS_Get_PID()
+/*
+**		Return the current process ID
+**
+***********************************************************************/
+{
+	return getpid();
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Get_UID()
+/*
+**		Return the real user ID
+**
+***********************************************************************/
+{
+	return getuid();
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Set_UID(REBINT uid)
+/*
+**		Set the user ID, see setuid manual for its semantics
+**
+***********************************************************************/
+{
+	if (setuid(uid) < 0) {
+		switch (errno) {
+			case EINVAL:
+				return OS_EINVAL;
+			case EPERM:
+				return OS_EPERM;
+			default:
+				return -errno;
+		}
+	} else {
+		return 0;
+	}
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Get_GID()
+/*
+**		Return the real group ID
+**
+***********************************************************************/
+{
+	return getgid();
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Set_GID(REBINT gid)
+/*
+**		Set the group ID, see setgid manual for its semantics
+**
+***********************************************************************/
+{
+	if (setgid(gid) < 0) {
+		switch (errno) {
+			case EINVAL:
+				return OS_EINVAL;
+			case EPERM:
+				return OS_EPERM;
+			default:
+				return -errno;
+		}
+	} else {
+		return 0;
+	}
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Get_EUID()
+/*
+**		Return the effective user ID
+**
+***********************************************************************/
+{
+	return geteuid();
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Set_EUID(REBINT uid)
+/*
+**		Set the effective user ID
+**
+***********************************************************************/
+{
+	if (seteuid(uid) < 0) {
+		switch (errno) {
+			case EINVAL:
+				return OS_EINVAL;
+			case EPERM:
+				return OS_EPERM;
+			default:
+				return -errno;
+		}
+	} else {
+		return 0;
+	}
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Get_EGID()
+/*
+**		Return the effective group ID
+**
+***********************************************************************/
+{
+	return getegid();
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Set_EGID(REBINT gid)
+/*
+**		Set the effective group ID
+**
+***********************************************************************/
+{
+	if (setegid(gid) < 0) {
+		switch (errno) {
+			case EINVAL:
+				return OS_EINVAL;
+			case EPERM:
+				return OS_EPERM;
+			default:
+				return -errno;
+		}
+	} else {
+		return 0;
+	}
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Send_Signal(REBINT pid, REBINT signal)
+/*
+**		Send signal to a process
+**
+***********************************************************************/
+{
+	if (kill(pid, signal) < 0) {
+		switch (errno) {
+			case EINVAL:
+				return OS_EINVAL;
+			case EPERM:
+				return OS_EPERM;
+			case ESRCH:
+				return OS_ESRCH;
+			default:
+				return -errno;
+		}
+	} else {
+		return 0;
+	}
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Kill(REBINT pid)
+/*
+**		Try to kill the process
+**
+***********************************************************************/
+{
+	return OS_Send_Signal(pid, SIGTERM);
+}
+
 /***********************************************************************
 **
 */	REBINT OS_Config(int id, REBYTE *result)

--- a/src/os/win32/host-lib.c
+++ b/src/os/win32/host-lib.c
@@ -130,6 +130,151 @@ static void *Task_Ready;
 
 /***********************************************************************
 **
+*/	REBINT OS_Get_PID()
+/*
+**		Return the current process ID
+**
+***********************************************************************/
+{
+	return GetCurrentProcessId();
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Get_UID()
+/*
+**		Return the real user ID
+**
+***********************************************************************/
+{
+	return OS_ENA;
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Set_UID(REBINT uid)
+/*
+**		Set the user ID, see setuid manual for its semantics
+**
+***********************************************************************/
+{
+	return OS_ENA;
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Get_GID()
+/*
+**		Return the real group ID
+**
+***********************************************************************/
+{
+	return OS_ENA;
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Set_GID(REBINT gid)
+/*
+**		Set the group ID, see setgid manual for its semantics
+**
+***********************************************************************/
+{
+	return OS_ENA;
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Get_EUID()
+/*
+**		Return the effective user ID
+**
+***********************************************************************/
+{
+	return OS_ENA;
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Set_EUID(REBINT uid)
+/*
+**		Set the effective user ID
+**
+***********************************************************************/
+{
+	return OS_ENA;
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Get_EGID()
+/*
+**		Return the effective group ID
+**
+***********************************************************************/
+{
+	return OS_ENA;
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Set_EGID(REBINT gid)
+/*
+**		Set the effective group ID
+**
+***********************************************************************/
+{
+	return OS_ENA;
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Send_Signal(REBINT pid, REBINT signal)
+/*
+**		Send signal to a process
+**
+***********************************************************************/
+{
+	return OS_ENA;
+}
+
+/***********************************************************************
+**
+*/	REBINT OS_Kill(REBINT pid)
+/*
+**		Try to kill the process
+**
+***********************************************************************/
+{
+	REBINT err = 0;
+	HANDLE ph = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
+	if (ph == NULL) {
+		err = GetLastError();
+		switch (err) {
+			case ERROR_ACCESS_DENIED:
+				return OS_EPERM;
+			case ERROR_INVALID_PARAMETER:
+				return OS_ESRCH;
+			default:
+				return OS_ESRCH;
+		}
+	}
+	if (TerminateProcess(ph, 0)) {
+		CloseHandle(ph);
+		return 0;
+	}
+	err = GetLastError();
+	CloseHandle(ph);
+	switch (err) {
+		case ERROR_INVALID_HANDLE:
+			return OS_EINVAL;
+		default:
+			return -err;
+	}
+}
+
+/***********************************************************************
+**
 */	REBINT OS_Config(int id, REBYTE *result)
 /*
 **		Return a specific runtime configuration parameter.

--- a/src/os/win32/host-lib.c
+++ b/src/os/win32/host-lib.c
@@ -235,6 +235,9 @@ static void *Task_Ready;
 **
 ***********************************************************************/
 {
+	if (signal == 9 || signal == 15) { //SIGKILL || SIGTERM
+		return OS_Kill(pid);
+	}
 	return OS_ENA;
 }
 


### PR DESCRIPTION
Based on commit: https://github.com/zsx/r3/commit/275c8672810f2beb760ecfeebcf82769da76b78e
But slightly modified - the OS_E* definitions were moved to reb-defs.h file and symbols are auto-collected in this branch. 

Original commit message:

> It's almost like what's in R2, with the addition of 'euid and 'egid, and
> additional signal number to kill the process:
>
> access-os/set 'pid [2123 9] ;send a signal 9 (SIGKILL) to process 2123